### PR TITLE
Upgrade to Java 21 and fix curl dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine@sha256:94792824df2df33402f201713f932b58cb9de94a0cd524164a0f2283343547b3
+FROM eclipse-temurin:21-jre-alpine
 LABEL "maintainer"="step-security <security@stepsecurity.io>"
 LABEL "com.github.actions.name"="release-notes-generator-action"
 LABEL "com.github.actions.description"="Create a release notes of milestone"
@@ -9,7 +9,8 @@ ENV RELEASE_NOTE_GENERATOR_VERSION="v0.0.8"
 ENV RELEASE_NOTE_GENERATOR_CHECKSUM="4ac5387565b3b6d050a6ecc7bc7188e7cf62bf464596603b233ece457a66be60"
 
 COPY *.sh /
-RUN chmod +x JSON.sh && \
+RUN apk add --no-cache curl && \
+    chmod +x JSON.sh && \
     wget -O github-release-notes-generator.jar https://github.com/spring-io/github-changelog-generator/releases/download/${RELEASE_NOTE_GENERATOR_VERSION}/github-changelog-generator.jar && \
     echo "$RELEASE_NOTE_GENERATOR_CHECKSUM  github-release-notes-generator.jar" | sha256sum -c -
 


### PR DESCRIPTION
- Update base image from openjdk:8-alpine to eclipse-temurin:21-jre-alpine
- Install curl package to fix missing curl dependency in entrypoint script
- Addresses security vulnerabilities in outdated Java 8 image

🤖 Generated with [Claude Code](https://claude.ai/code)