### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV RELEASE_NOTE_GENERATOR_VERSION="v0.0.12"
 ENV RELEASE_NOTE_GENERATOR_CHECKSUM="f42a5b90e3b3cc02c74d289b36af36c317c71d4be67d86f575cc3a853d9e3c7e"
 
 COPY *.sh /
-RUN apk add --no-cache curl && \
+RUN apk add --no-cache curl jq && \
     chmod +x JSON.sh && \
     wget -O github-release-notes-generator.jar https://github.com/spring-io/github-changelog-generator/releases/download/${RELEASE_NOTE_GENERATOR_VERSION}/github-changelog-generator.jar && \
     echo "$RELEASE_NOTE_GENERATOR_CHECKSUM  github-release-notes-generator.jar" | sha256sum -c -

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2023 StepSecurity
+   Copyright (c) 2026 StepSecurity
    Copyright 2019 Decathlon
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 <h1>
   <p align="center">
     Release Note Generator GitHub Action

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,22 +11,44 @@ OWNER_ID=$(/JSON.sh < "${GITHUB_EVENT_PATH}" | grep '\["repository","owner","log
 GH_USERNAME=$(/JSON.sh < "${GITHUB_EVENT_PATH}" | grep '\["sender","login"]' | cut -f2 | sed 's/\"//g')
 PROVIDED_MILESTONE_ID=$(/JSON.sh < "${GITHUB_EVENT_PATH}" | grep '\["inputs","milestoneId"]' | cut -f2 | sed 's/\"//g')
 
-API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+REPO_PRIVATE=$(jq -r '.repository.private | tostring' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+UPSTREAM="Decathlon/release-notes-generator-action"
+ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-# Set a timeout for the curl command (3 seconds)
-RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-CURL_EXIT_CODE=${?}
+echo ""
+echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+echo "Secure drop-in replacement for $UPSTREAM"
+if [ "$REPO_PRIVATE" = "false" ]; then
+  echo -e "\033[32m✓ Free for public repositories\033[0m"
+fi
+echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+echo ""
 
-# Check if the response code is not 200
-if [ $CURL_EXIT_CODE -ne 0 ]; then
-  echo "Timeout or API not reachable. Continuing to next step."
-elif [ "$RESPONSE" = "200" ]; then
-  :
-elif [ "$RESPONSE" = "403" ]; then
-  echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-  exit 1
-else
-  echo "Timeout or API not reachable. Continuing to next step."
+if [ "$REPO_PRIVATE" != "false" ]; then
+  SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+  if [ "$SERVER_URL" != "https://github.com" ]; then
+    BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+  else
+    BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+  fi
+
+  API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+  RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$BODY" \
+    "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+  if [ $CURL_EXIT_CODE -ne 0 ]; then
+    echo "Timeout or API not reachable. Continuing to next step."
+  elif [ "$RESPONSE" = "403" ]; then
+    echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+    echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+    exit 1
+  fi
 fi
 
 MILESTONE_ID_TO_USE=${MILESTONE_NUMBER:-$PROVIDED_MILESTONE_ID}


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Updated LICENSE copyright year to 2026
- Added jq to Dockerfile for event payload parsing

## Changes by type
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top

Auto-generated by StepSecurity update-propagator. Task ID: 20260409T074908Z